### PR TITLE
Correct repository fields

### DIFF
--- a/dockerfile-lint-extension/extension/package.json
+++ b/dockerfile-lint-extension/extension/package.json
@@ -58,7 +58,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples/tree/master/dockerfile-lint-extension"
+    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples",
+    "directory": "dockerfile-lint-extension"
   },
   "browserslist": [
     "last 1 Chrome versions",

--- a/line-counter/package.json
+++ b/line-counter/package.json
@@ -38,6 +38,11 @@
   "version": "0.0.0-DEVELOPMENT",
   "license": "MIT",
   "main": "dist/sourcegraph-line-counter.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples",
+    "directory": "line-counter"
+  },
   "scripts": {
     "tslint": "tslint -p tsconfig.json './src/**/*.ts'",
     "typecheck": "tsc -p tsconfig.json",

--- a/npm-import-stats/package.json
+++ b/npm-import-stats/package.json
@@ -4,7 +4,8 @@
   "title": "npm import stats",
   "description": "Displays stats about npm packages next to import statements.",
   "repository": {
-    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples.git"
+    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples.git",
+    "directory": "npm-import-stats"
   },
   "activationEvents": [
     "*"

--- a/token-highlights/package.json
+++ b/token-highlights/package.json
@@ -7,6 +7,11 @@
     "*"
   ],
   "main": "dist/extension.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph-extension-samples",
+    "directory": "token-highlights"
+  },
   "scripts": {
     "sourcegraph:prepublish": "parcel build src/extension.ts"
   },


### PR DESCRIPTION
"url" needs to be a valid git clone URL
"directory" can be used to specify the directory
TypeScript global references relies on these fields